### PR TITLE
feat: use glibc compatible alpine image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,7 +5,7 @@ FROM golang:1.21-alpine3.18 AS builder
 COPY . /build/
 RUN cd /build && ./build.sh
 
-FROM alpine:3.18
+FROM frolvlad/alpine-glibc:alpine-3.18
 
 RUN apk add --no-cache bash curl jq git ffmpeg \
 	# Python for python bridges


### PR DESCRIPTION
I have tested this alpine image and it fixes the signalgo support. The reason this is needed is because signalgo is built on Ubuntu, which uses glibc.

I have tested discord, signal, and Instagram, they all seem to work still with this image.

This image is very well knows and actively maintained: https://hub.docker.com/r/frolvlad/alpine-glibc/


Thank you @charleywright for assisting me in figuring out what the exact issue was.