### PR TITLE
Added crontab for reboot management

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,9 +75,11 @@ Use crontab to set the bridge up to start on reboot. If you would like logging
 add the following entry to your crontab and replace `<bbctl path>` with the location of 
 bbctl, `<bridge name>` with the name of the bridge, and `<log path>` with the 
 location of where you would like logs saved:
+
 `@reboot /<path>/bbctl run  <bridge name> > /<log path>/<bridge name>.log`
 
 If you do not want logging add the following to your crontab:
+
 `@reboot /<path>/bbctl run  <bridge name> > /dev/null`
 
 In the future, a service mode will be

--- a/README.md
+++ b/README.md
@@ -69,7 +69,18 @@ bot in another Matrix client, or using the create group chat button in Beeper
 Desktop.
 
 Currently the bridge will run in foreground, so you'll have to keep `bbctl run`
-active somewhere (tmux is a good option). In the future, a service mode will be
+active somewhere (tmux is a good option). 
+
+Use crontab to set the bridge up to start on reboot. If you would like logging
+add the following entry to your crontab and replace `<bbctl path>` with the location of 
+bbctl, `<bridge name>` with the name of the bridge, and `<log path>` with the 
+location of where you would like logs saved:
+`@reboot /<path>/bbctl run  <bridge name> > /<log path>/<bridge name>.log`
+
+If you do not want logging add the following to your crontab:
+`@reboot /<path>/bbctl run  <bridge name> > /dev/null`
+
+In the future, a service mode will be
 added where the bridge is registered as a systemd or launchd service to be
 started automatically by the OS.
 


### PR DESCRIPTION
This pull request adds instructions to the README for using crontab to auto start the bridges upon planned or unexpected reboots. I included two options with and without logging. I have tested this on Ubuntu 22.04 with success. Crontab will work across all Linux distributions and should also work on macOS. 