### PR TITLE
Update default config for sh-imessage

### DIFF
--- a/bridgeconfig/discord.tpl.yaml
+++ b/bridgeconfig/discord.tpl.yaml
@@ -111,7 +111,7 @@ bridge:
     # If set to `default`, this will be enabled in encrypted rooms and disabled in unencrypted rooms.
     # If set to `always`, all DM rooms will have explicit names and avatars set.
     # If set to `never`, DM rooms will never have names and avatars set.
-    private_chat_portal_meta: never
+    private_chat_portal_meta: default
 
     portal_message_buffer: 128
 

--- a/bridgeconfig/facebook.tpl.yaml
+++ b/bridgeconfig/facebook.tpl.yaml
@@ -283,7 +283,7 @@ bridge:
     # If set to `default`, this will be enabled in encrypted rooms and disabled in unencrypted rooms.
     # If set to `always`, all DM rooms will have explicit names and avatars set.
     # If set to `never`, DM rooms will never have names and avatars set.
-    private_chat_portal_meta: never
+    private_chat_portal_meta: default
     # Disable generating reply fallbacks? Some extremely bad clients still rely on them,
     # but they're being phased out and will be completely removed in the future.
     disable_reply_fallbacks: true

--- a/bridgeconfig/gmessages.tpl.yaml
+++ b/bridgeconfig/gmessages.tpl.yaml
@@ -150,7 +150,7 @@ bridge:
     # If set to `default`, this will be enabled in encrypted rooms and disabled in unencrypted rooms.
     # If set to `always`, all DM rooms will have explicit names and avatars set.
     # If set to `never`, DM rooms will never have names and avatars set.
-    private_chat_portal_meta: never
+    private_chat_portal_meta: default
     # Should Matrix m.notice-type messages be bridged?
     bridge_notices: true
     # Set this to true to tell the bridge to re-send m.bridge events to all rooms on the next run.

--- a/bridgeconfig/googlechat.tpl.yaml
+++ b/bridgeconfig/googlechat.tpl.yaml
@@ -242,7 +242,7 @@ bridge:
     # If set to `default`, this will be enabled in encrypted rooms and disabled in unencrypted rooms.
     # If set to `always`, all DM rooms will have explicit names and avatars set.
     # If set to `never`, DM rooms will never have names and avatars set.
-    private_chat_portal_meta: never
+    private_chat_portal_meta: default
 
     provisioning:
         # Internal prefix in the appservice web server for the login endpoints.

--- a/bridgeconfig/imessage.tpl.yaml
+++ b/bridgeconfig/imessage.tpl.yaml
@@ -153,7 +153,7 @@ bridge:
         # Maximum number of messages to backfill for new portal rooms.
         initial_limit: 100
         # Maximum age of chats to sync in days.
-        initial_sync_max_age: 0.5
+        initial_sync_max_age: 14
         # If a backfilled chat is older than this number of hours, mark it as read even if it's unread on iMessage.
         # Set to -1 to let any chat be unread.
         unread_hours_threshold: 720

--- a/bridgeconfig/imessage.tpl.yaml
+++ b/bridgeconfig/imessage.tpl.yaml
@@ -218,7 +218,7 @@ bridge:
     caption_in_message: true
     # Should the bridge explicitly set the avatar and room name for private chat portal rooms?
     # This is implicitly enabled in encrypted rooms.
-    private_chat_portal_meta: never
+    private_chat_portal_meta: auto
 
     # End-to-bridge encryption support options.
     # See https://docs.mau.fi/bridges/general/end-to-bridge-encryption.html

--- a/bridgeconfig/imessage.tpl.yaml
+++ b/bridgeconfig/imessage.tpl.yaml
@@ -153,7 +153,7 @@ bridge:
         # Maximum number of messages to backfill for new portal rooms.
         initial_limit: 100
         # Maximum age of chats to sync in days.
-        initial_sync_max_age: 14
+        initial_sync_max_age: 7
         # If a backfilled chat is older than this number of hours, mark it as read even if it's unread on iMessage.
         # Set to -1 to let any chat be unread.
         unread_hours_threshold: 720

--- a/bridgeconfig/imessage.tpl.yaml
+++ b/bridgeconfig/imessage.tpl.yaml
@@ -218,7 +218,7 @@ bridge:
     caption_in_message: true
     # Should the bridge explicitly set the avatar and room name for private chat portal rooms?
     # This is implicitly enabled in encrypted rooms.
-    private_chat_portal_meta: auto
+    private_chat_portal_meta: default
 
     # End-to-bridge encryption support options.
     # See https://docs.mau.fi/bridges/general/end-to-bridge-encryption.html

--- a/bridgeconfig/imessagego.tpl.yaml
+++ b/bridgeconfig/imessagego.tpl.yaml
@@ -139,7 +139,7 @@ bridge:
     # If set to `default`, this will be enabled in encrypted rooms and disabled in unencrypted rooms.
     # If set to `always`, all DM rooms will have explicit names and avatars set.
     # If set to `never`, DM rooms will never have names and avatars set.
-    private_chat_portal_meta: never
+    private_chat_portal_meta: default
     # Should iMessage reply threads be mapped to Matrix threads? If false, iMessage reply threads will be bridged
     # as replies to the previous message in the thread.
     matrix_threads: false

--- a/bridgeconfig/instagram.tpl.yaml
+++ b/bridgeconfig/instagram.tpl.yaml
@@ -297,7 +297,7 @@ bridge:
     # If set to `default`, this will be enabled in encrypted rooms and disabled in unencrypted rooms.
     # If set to `always`, all DM rooms will have explicit names and avatars set.
     # If set to `never`, DM rooms will never have names and avatars set.
-    private_chat_portal_meta: never
+    private_chat_portal_meta: default
     # Whether or not the bridge should send a read receipt from the bridge bot when a message has
     # been sent to Instagram.
     delivery_receipts: false

--- a/bridgeconfig/meta.tpl.yaml
+++ b/bridgeconfig/meta.tpl.yaml
@@ -98,7 +98,7 @@ bridge:
     # If set to `default`, this will be enabled in encrypted rooms and disabled in unencrypted rooms.
     # If set to `always`, all DM rooms will have explicit names and avatars set.
     # If set to `never`, DM rooms will never have names and avatars set.
-    private_chat_portal_meta: never
+    private_chat_portal_meta: default
 
     portal_message_buffer: 128
 

--- a/bridgeconfig/signal.tpl.yaml
+++ b/bridgeconfig/signal.tpl.yaml
@@ -97,7 +97,7 @@ bridge:
     # If set to `default`, this will be enabled in encrypted rooms and disabled in unencrypted rooms.
     # If set to `always`, all DM rooms will have explicit names and avatars set.
     # If set to `never`, DM rooms will never have names and avatars set.
-    private_chat_portal_meta: never
+    private_chat_portal_meta: default
     # Should avatars from the user's contact list be used? This is not safe on multi-user instances.
     use_contact_avatars: true
     # Should the Signal user's phone number be included in the room topic in private chat portal rooms?

--- a/bridgeconfig/slack.tpl.yaml
+++ b/bridgeconfig/slack.tpl.yaml
@@ -113,7 +113,7 @@ bridge:
     # If set to `default`, this will be enabled in encrypted rooms and disabled in unencrypted rooms.
     # If set to `always`, all DM rooms will have explicit names and avatars set.
     # If set to `never`, DM rooms will never have names and avatars set.
-    private_chat_portal_meta: never
+    private_chat_portal_meta: default
 
     # Servers to always allow double puppeting from
     double_puppet_server_map:

--- a/bridgeconfig/telegram.tpl.yaml
+++ b/bridgeconfig/telegram.tpl.yaml
@@ -338,7 +338,7 @@ bridge:
     # If set to `default`, this will be enabled in encrypted rooms and disabled in unencrypted rooms.
     # If set to `always`, all DM rooms will have explicit names and avatars set.
     # If set to `never`, DM rooms will never have names and avatars set.
-    private_chat_portal_meta: never
+    private_chat_portal_meta: default
     # Disable generating reply fallbacks? Some extremely bad clients still rely on them,
     # but they're being phased out and will be completely removed in the future.
     disable_reply_fallbacks: true

--- a/bridgeconfig/twitter.tpl.yaml
+++ b/bridgeconfig/twitter.tpl.yaml
@@ -240,7 +240,7 @@ bridge:
     # If set to `default`, this will be enabled in encrypted rooms and disabled in unencrypted rooms.
     # If set to `always`, all DM rooms will have explicit names and avatars set.
     # If set to `never`, DM rooms will never have names and avatars set.
-    private_chat_portal_meta: never
+    private_chat_portal_meta: default
     # Whether or not the bridge should send a read receipt from the bridge bot when a message has
     # been sent to Twitter.
     delivery_receipts: false

--- a/bridgeconfig/whatsapp.tpl.yaml
+++ b/bridgeconfig/whatsapp.tpl.yaml
@@ -238,7 +238,7 @@ bridge:
     # If set to `default`, this will be enabled in encrypted rooms and disabled in unencrypted rooms.
     # If set to `always`, all DM rooms will have explicit names and avatars set.
     # If set to `never`, DM rooms will never have names and avatars set.
-    private_chat_portal_meta: never
+    private_chat_portal_meta: default
     # Should group members be synced in parallel? This makes member sync faster
     parallel_member_sync: true
     # Should Matrix m.notice-type messages be bridged?


### PR DESCRIPTION
Updates default number of days to backfill from 0.5 days to 2 weeks, changes param to fix imessage contact names and photos across all platforms. Tested with bluebubbles and applescript connectors