### PR TITLE
Use stable address for Hungryserv

### DIFF
--- a/cmd/bbctl/whoami.go
+++ b/cmd/bbctl/whoami.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"regexp"
 	"sort"
 	"strings"
@@ -169,8 +170,13 @@ func getCachedWhoami(ctx *cli.Context) (*beeperapi.RespWhoami, error) {
 		ec.ClusterID = resp.UserInfo.BridgeClusterID
 		changed = true
 	}
-	if ec.HungryAddress != resp.UserInfo.HungryURL {
-		ec.HungryAddress = resp.UserInfo.HungryURL
+	publicHungryURL := url.URL{
+		Scheme: "https",
+		Host:   "matrix." + ctx.String("homeserver"),
+		Path:   "/_hungryserv/" + resp.UserInfo.Username,
+	}
+	if ec.HungryAddress != publicHungryURL.String() {
+		ec.HungryAddress = publicHungryURL.String()
 		changed = true
 	}
 	if changed {


### PR DESCRIPTION
Removes the requirement to update bridge config if it moves.

Depends on an internal change. Can be merged if/when that is deployed.