### PR TITLE
 Improve Docker Build and Deployment for Multi-Arch Support (arm64)

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -91,7 +91,7 @@ jobs:
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |
-            type=raw,value=latest,enable=${{  github.ref == 'refs/heads/main' }}
+            type=raw,value=latest,enable={{is_default_branch}}
             type=sha,format=long,prefix=
 
       - name: Docker Build

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -92,7 +92,7 @@ jobs:
           images: ghcr.io/${{ github.repository }}
           tags: |
             type=raw,value=latest,enable=${{  github.ref == 'refs/heads/main' }}
-            type=sha,format=long
+            type=sha,format=long,prefix=
 
       - name: Docker Build
         uses: docker/build-push-action@v5

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -90,6 +90,7 @@ jobs:
         with:
           cache-from: ${{ env.GHCR_REGISTRY_IMAGE }}:latest
           pull: true
+          platforms: linux/amd64,linux/arm64
           file: docker/Dockerfile
           tags: ${{ env.GHCR_REGISTRY_IMAGE }}:${{ github.sha }}
           push: true

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -85,6 +85,15 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Extract Docker metadata
+        id: metadata
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=raw,value=latest,enable=${{  github.ref == 'refs/heads/main' }}
+            type=semver,pattern={{version}}
+
       - name: Docker Build
         uses: docker/build-push-action@v5
         with:
@@ -92,24 +101,8 @@ jobs:
           pull: true
           platforms: linux/amd64,linux/arm64
           file: docker/Dockerfile
-          tags: ${{ env.GHCR_REGISTRY_IMAGE }}:${{ github.sha }}
+          tags: ${{ steps.metadata.outputs.tags }}
+          labels: ${{ steps.metadata.outputs.labels }}
           push: true
           build-args: |
             COMMIT_HASH=${{ github.sha }}
-
-  deploy-docker:
-    runs-on: ubuntu-latest
-    needs:
-      - build-docker
-    if: github.ref == 'refs/heads/main'
-    steps:
-      - name: Login to registry
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.GHCR_REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - uses: beeper/docker-retag-push-latest@main
-        with:
-          image: ${{ env.GHCR_REGISTRY_IMAGE }}

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -93,7 +93,6 @@ jobs:
           tags: |
             type=raw,value=latest,enable=${{  github.ref == 'refs/heads/main' }}
             type=sha,format=long
-            type=ref
 
       - name: Docker Build
         uses: docker/build-push-action@v5

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -92,7 +92,8 @@ jobs:
           images: ghcr.io/${{ github.repository }}
           tags: |
             type=raw,value=latest,enable=${{  github.ref == 'refs/heads/main' }}
-            type=semver,pattern={{version}}
+            type=sha,format=long
+            type=ref
 
       - name: Docker Build
         uses: docker/build-push-action@v5


### PR DESCRIPTION
Add multi-arch support for Docker images: The previous implementation did not handle multi-arch correctly. This PR updates the Docker build process to support multiple architectures (linux/amd64 and linux/arm64) using the docker/metadata-action and docker/build-push-action.

Tested the changes on an arm machine and verified the build with the GitHub Container Registry.

     

Fixes: #25 

Additional Note: The `beeper/docker-retag-push-latest` action does not seem to handle multi-arch correctly, which is a separate issue that needs to be addressed.

Verification: Please verify the changes by checking the Docker image on the GitHub Container Registry: https://github.com/slikie/bridge-manager/pkgs/container/bridge-manager

