### PR TITLE
docs(README): correct the path to the configuration file

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ After installing relevant dependencies:
      Otherwise pass the type with `--type <type>`.
    * See the table below for supported official bridges.
    * The bridge will be installed to `~/.local/share/bbctl`. You can change the
-     directory in the config file at `~/.config/bbctl.json`.
+     directory in the config file at `~/.config/bbctl/config.json`.
 4. For now, you'll have to configure the bridge by sending a DM to the bridge
    bot (`@<name>bot:beeper.local`). Configuring self-hosted bridges through the
    chat networks dialog will be available in the future. Spaces and starting


### PR DESCRIPTION
I noticed a discrepancy between the documentation and a fresh installation of the `bbctl` binary, where the configuration file is generated at `~/.config/bbctl/config.json` instead of `~/.config/bbctl.json`. This pull request corrects that inconsistency.