### PR TITLE
Using Docker recommended ENTRYPOINT instructions for Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -23,4 +23,4 @@ COPY ./docker/run-bridge.sh /usr/local/bin/run-bridge.sh
 ENV SYSTEM_SITE_PACKAGES=true
 VOLUME /data
 
-ENTRYPOINT /usr/local/bin/run-bridge.sh
+ENTRYPOINT ["/usr/local/bin/run-bridge.sh"]


### PR DESCRIPTION
Running the docker image was causing some issues on my end
`/usr/local/bin/run-bridge.sh: line 4: $1: unbound variable`
Decided to build the image and got the warning even though the build was success. And still got the same error running the docker image.
# The warning from docker build
```bash
 1 warning found:
 - JSONArgsRecommended: JSON arguments recommended for ENTRYPOINT to prevent unintended behavior related to OS signals (line 26)      
JSON arguments recommended for ENTRYPOINT/CMD to prevent unintended behavior related to OS signals
More info: https://docs.docker.com/go/dockerfile/rule/json-args-recommended/
Dockerfile:26
```

Fixed/modified based on the [recommendation](https://docs.docker.com/go/dockerfile/rule/json-args-recommended/), and the build is working fine.
