### PR TITLE
Build multi-platform Docker image in CI

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -89,6 +89,7 @@ jobs:
       - name: Docker Build
         uses: docker/build-push-action@v5
         with:
+          platforms: linux/amd64,linux/arm64
           cache-from: ${{ env.GHCR_REGISTRY_IMAGE }}:latest
           pull: true
           file: docker/Dockerfile


### PR DESCRIPTION
Note that due to a bug in https://github.com/beeper/docker-retag-push-latest/issues/1 the tag `:latest` will only contain the `amd64`-only image, but the multi-arch image will be uploaded and usable by directly referencing the `:commit_hash`.
