### PR TITLE
Accept 'messenger' as a valid bridge intentifier for meta

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ used with the `--type` flag.
 | [mautrix-slack]      | slack                                |
 | [mautrix-gmessages]  | gmessages,  googlemessages, rcs, sms |
 | [mautrix-gvoice]     | gvoice, googlevoice                  |
-| [mautrix-meta]       | meta, instagram, facebook            |
+| [mautrix-meta]       | meta, instagram, facebook, messenger |
 | [mautrix-googlechat] | googlechat, gchat                    |
 | [mautrix-twitter]    | twitter                              |
 | [mautrix-bluesky]    | bluesky, bsky                        |

--- a/cmd/bbctl/bridgeutil.go
+++ b/cmd/bbctl/bridgeutil.go
@@ -22,7 +22,7 @@ type bridgeTypeToNames struct {
 
 var officialBridges = []bridgeTypeToNames{
 	{"discord", []string{"discord"}},
-	{"meta", []string{"meta", "instagram", "facebook"}},
+	{"meta", []string{"meta", "instagram", "facebook", "messenger"}},
 	{"googlechat", []string{"googlechat", "gchat"}},
 	{"imessagego", []string{"imessagego"}},
 	{"imessage", []string{"imessage"}},


### PR DESCRIPTION
While the code supported 'messenger' as a valid meta platform, it was not exposed via an identifier. This made it impossible to start a messenger bridge via docker, since it would then prompt to select a valid bridge.