### PR TITLE
Fix username rendering for users without display name set

### DIFF
--- a/bridgeconfig/slack.tpl.yaml
+++ b/bridgeconfig/slack.tpl.yaml
@@ -16,7 +16,7 @@ network:
     #  .Profile.Pronouns - The pronouns of the user
     #  .Profile.Email - The email address of the user
     #  .Profile.Phone - The formatted phone number of the user
-    displayname_template: '{{ `{{.Profile.DisplayName}}{{if .IsBot}} (bot){{end}}` }}'
+    displayname_template: '{{ `{{or .Profile.DisplayName .Profile.RealName .Name}}{{if .IsBot}} (bot){{end}}` }}'
     # Channel name template for Slack channels (all types). Available variables:
     #  .Name - The name of the channel
     #  .TeamName - The name of the team the channel is in


### PR DESCRIPTION
Bring displayname_template up to date with https://github.com/mautrix/slack/commit/ab940570f74b259f995d94a6acabfdc705416d51.

Fixes bug that renders the usernames of people without display names set as UIDs (instead of falling back to real names), e.g. 
![image](https://github.com/user-attachments/assets/6c5a22ac-80de-4d59-b231-a20668c44730)
